### PR TITLE
Feature/citrix adc rewrite policy

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -21,4 +21,4 @@ jobs:
     - name: Test with pylint
       run: |
         pip install pylint
-        pylint ansible-modules/citrix_adc_rewrite_action.py
+        pylint -E ansible-modules/*.py

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -21,4 +21,4 @@ jobs:
     - name: Test with pylint
       run: |
         pip install pylint
-        pylint ansible-modules/*
+        pylint ansible-modules/citrix_adc_rewrite_action.py

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -17,8 +17,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.test.txt
-        python install.py
-    - name: Test with pylint
-      run: |
         pip install pylint
-        pylint -E ansible-modules/*.py
+        python install.py
+    - name: Test Citrix ADC ansible modules with pylint
+      run: |
+        pylint -E ansible-modules/citrix_adc_*.py
+    - name: Test Citrix ADM ansible modules with pylint
+      run: |
+        pylint -E ansible-modules/citrix_adm_*.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.retry
 *.pyc
 .tox/
+virtualenvironment/

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Currently the following modules are implemented
 * citrix\_adc\_lb\_vserver - Manage load balancing vserver configuration
 * citrix\_adc\_nitro\_request - Issue Nitro API requests to a Citrix ADC instance
 * citrix\_adc\_nitro\_resource - Create, update, delete resources on Citrix ADC
+* citrix\_adc\_rewrite\_action - Manage rewrite actions
 * citrix\_adc\_save\_config - Save Citrix ADC configuration
 * citrix\_adc\_server - Manage server configuration
 * citrix\_adc\_service - Manage service configuration in Citrix ADC
@@ -265,4 +266,4 @@ See [LICENSE](./LICENSE)
 **COPYRIGHT 2017 CITRIX Systems Inc**
 
 ## Contributions
-Pull requests and issues are welcome. 
+Pull requests and issues are welcome.

--- a/ansible-modules/citrix_adc_nitro_request.py
+++ b/ansible-modules/citrix_adc_nitro_request.py
@@ -821,7 +821,7 @@ class NitroAPICaller(object):
         )
 
         result = {}
-        self.edit_response_data(r, info, result)
+        self.edit_response_data(r, info, result, success_status=200)
 
         if result['http_response_body'] != '':
             data = self._module.from_json(result['http_response_body'])

--- a/ansible-modules/citrix_adc_rewrite_action.py
+++ b/ansible-modules/citrix_adc_rewrite_action.py
@@ -48,6 +48,31 @@ options:
                 policy is added.
 
     type:
+        choices:
+            - 'noop'
+            - 'delete'
+            - 'insert_http_header'
+            - 'delete_http_header'
+            - 'corrupt_http_header'
+            - 'insert_before'
+            - 'insert_after'
+            - 'replace'
+            - 'replace_http_res'
+            - 'delete_all'
+            - 'replace_all'
+            - 'insert_before_all'
+            - 'insert_after_all'
+            - 'clientless_vpn_encode'
+            - 'clientless_vpn_encode_all'
+            - 'clientless_vpn_decode'
+            - 'clientless_vpn_decode_all'
+            - 'insert_sip_header'
+            - 'delete_sip_header'
+            - 'corrupt_sip_header'
+            - 'replace_sip_res'
+            - 'replace_diameter_header_field'
+            - 'replace_dns_header_field'
+            - 'replace_dns_answer_section
         description:
             - >-
                 Type of user-defined rewrite action. The information that you provide for, and the effect of, each
@@ -79,7 +104,7 @@ options:
             - >-
                 Search facility that is used to match multiple strings in the request or response. Used in the
                 INSERT_BEFORE_ALL, INSERT_AFTER_ALL, REPLACE_ALL, and DELETE_ALL action types. The following search
-                types are supported:
+                types are supported: text(), regex(), xpath(), xpath_json(), xpath_html(), patset(), dataset(), avp()
 
     bypasssafetycheck:
         description:
@@ -131,9 +156,59 @@ requirements:
 '''
 
 EXAMPLES = '''
+# Create or update a rewrite action with citrix_adc_rewrite_action ansible module
+
+- name: Setup basic rewrite action
+  delegate_to: localhost
+  register: result
+  check_mode: "{{ check_mode }}"
+  citrix_adc_rewrite_action:
+    nitro_user: "{{nitro_user}}"
+    nitro_pass: "{{nitro_pass}}"
+    nsip: "{{nsip}}"
+
+    state: present
+
+    name: test-rewriteaction-1
+    type: insert_http_header
+    target: "client-IP"
+    stringbuilderexpr: CLIENT.IP.SRC
+
+# Delete an existing rewrite action
+
+- name: Remove basic rewrite action
+  delegate_to: localhost
+  register: result
+  check_mode: "{{ check_mode }}"
+  citrix_adc_rewrite_action:
+    nitro_user: "{{nitro_user}}"
+    nitro_pass: "{{nitro_pass}}"
+    nsip: "{{nsip}}"
+
+    state: absent
+
+    name: test-rewriteaction-1
+
 '''
 
 RETURN = '''
+loglines:
+    description: list of logged messages by the module
+    returned: always
+    type: list
+    sample: ['message 1', 'message 2']
+
+msg:
+    description: Message detailing the failure reason
+    returned: failure
+    type: str
+    sample: "Action does not exist"
+
+diff:
+    description: List of differences between the actual configured object and the configuration specified in the module
+    returned: failure
+    type: dict
+    sample: { 'clttimeout': 'difference. ours: (float) 10.0 other: (float) 20.0' }
 '''
 
 import json
@@ -179,7 +254,35 @@ def main():
 
     module_specific_arguments = dict(
         name=dict(type='str'),
-        type=dict(type='str'),
+        type=dict(
+            type='str',
+            choices=[
+                'noop',
+                'delete',
+                'insert_http_header',
+                'delete_http_header',
+                'corrupt_http_header',
+                'insert_before',
+                'insert_after',
+                'replace',
+                'replace_http_res',
+                'delete_all',
+                'replace_all',
+                'insert_before_all',
+                'insert_after_all',
+                'clientless_vpn_encode',
+                'clientless_vpn_encode_all',
+                'clientless_vpn_decode',
+                'clientless_vpn_decode_all',
+                'insert_sip_header',
+                'delete_sip_header',
+                'corrupt_sip_header',
+                'replace_sip_res',
+                'replace_diameter_header_field',
+                'replace_dns_header_field',
+                'replace_dns_answer_section'
+            ]
+        ),
         target=dict(type='str'),
         stringbuilderexpr=dict(type='str'),
         pattern=dict(type='str'),

--- a/ansible-modules/citrix_adc_rewrite_action.py
+++ b/ansible-modules/citrix_adc_rewrite_action.py
@@ -1,0 +1,336 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+#  Copyright (c) 2017 Citrix Systems
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.0'}
+
+
+DOCUMENTATION = '''
+---
+module: citrix_adc_rewriteaction
+short_description: Manage rewrite action configuration
+description:
+    - _
+
+version_added: "2.4.0"
+
+author: George Nikolopoulos (@giorgos-nikolopoulos)
+
+options:
+
+    name:
+        description:
+            - >-
+                Name for the user-defined rewrite action. Must begin with a letter, number, or the underscore
+                character (_), and must contain only letters, numbers, and the hyphen (-), period (.) hash (#), space
+                ( ), at (@), equals (=), colon (:), and underscore characters. Can be changed after the rewrite
+                policy is added.
+
+    type:
+        description:
+            - >-
+                Type of user-defined rewrite action. The information that you provide for, and the effect of, each
+                type are as follows::
+
+    target:
+        description:
+            - "Default syntax expression that specifies which part of the request or response to rewrite."
+
+    stringbuilderexpr:
+        description:
+            - >-
+                Default syntax expression that specifies the content to insert into the request or response at the
+                specified location, or that replaces the specified string.
+
+    pattern:
+        description:
+            - >-
+                DEPRECATED in favor of -search: Pattern that is used to match multiple strings in the request or
+                response. The pattern may be a string literal (without quotes) or a PCRE-format regular expression
+                with a delimiter that consists of any printable ASCII non-alphanumeric character except for the
+                underscore (_) and space ( ) that is not otherwise used in the expression. Example:
+                re~https?://|HTTPS?://~ The preceding regular expression can use the tilde (~) as the delimiter
+                because that character does not appear in the regular expression itself. Used in the
+                INSERT_BEFORE_ALL, INSERT_AFTER_ALL, REPLACE_ALL, and DELETE_ALL action types.
+
+    search:
+        description:
+            - >-
+                Search facility that is used to match multiple strings in the request or response. Used in the
+                INSERT_BEFORE_ALL, INSERT_AFTER_ALL, REPLACE_ALL, and DELETE_ALL action types. The following search
+                types are supported:
+
+    bypasssafetycheck:
+        description:
+            - >-
+                Bypass the safety check and allow unsafe expressions. An unsafe expression is one that contains
+                references to message elements that might not be present in all messages. If an expression refers to
+                a missing request element, an empty string is used instead.
+
+    refinesearch:
+        description:
+            - "Specify additional criteria to refine the results of the search."
+
+    comment:
+        description:
+            - "Comment. Can be used to preserve information about this rewrite action."
+
+    newname:
+        description:
+            - "New name for the rewrite action."
+
+    hits:
+        description:
+            - "The number of times the action has been taken."
+
+    undefhits:
+        description:
+            - "The number of times the action resulted in UNDEF."
+
+    referencecount:
+        description:
+            - "The number of references to the action."
+
+    description:
+        description:
+            - "Description of the action."
+
+    isdefault:
+        description:
+            - "A value of true is returned if it is a default rewriteaction."
+
+    builtin:
+        description:
+            - "Flag to determine whether rewrite action is built-in or not."
+
+
+extends_documentation_fragment: netscaler
+requirements:
+    - nitro python sdk
+'''
+
+EXAMPLES = '''
+'''
+
+RETURN = '''
+'''
+
+import json
+
+try:
+    from nssrc.com.citrix.netscaler.nitro.resource.config.rewrite.rewriteaction import rewriteaction
+    from nssrc.com.citrix.netscaler.nitro.exception.nitro_exception import nitro_exception
+    PYTHON_SDK_IMPORTED = True
+except ImportError as e:
+    PYTHON_SDK_IMPORTED = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.netscaler.netscaler import (
+    ConfigProxy,
+    get_nitro_client,
+    netscaler_common_arguments,
+    log, loglines,
+    ensure_feature_is_enabled,
+    get_immutables_intersection
+)
+
+
+def rewriteaction_exists(client, module):
+    if rewriteaction.count_filtered(client, 'name:%s' % module.params['name']) > 0:
+        return True
+    else:
+        return False
+
+
+def rewriteaction_identical(client, module, rewriteaction_proxy):
+    if len(diff_list(client, module, rewriteaction_proxy)) == 0:
+        return True
+    else:
+        return False
+
+
+def diff_list(client, module, rewriteaction_proxy):
+    action_list = rewriteaction.get_filtered(client, 'name:%s' % module.params['name'])
+    diff_list = rewriteaction_proxy.diff_object(action_list[0])
+    return diff_list
+
+def main():
+
+    module_specific_arguments = dict(
+        name=dict(type='str'),
+        type=dict(type='str'),
+        target=dict(type='str'),
+        stringbuilderexpr=dict(type='str'),
+        pattern=dict(type='str'),
+        search=dict(type='str'),
+        bypasssafetycheck=dict(type='str'),
+        refinesearch=dict(type='str'),
+        comment=dict(type='str'),
+        newname=dict(type='str'),
+        hits=dict(type='float'),
+        undefhits=dict(type='float'),
+        referencecount=dict(type='float'),
+        description=dict(type='str'),
+        isdefault=dict(type='bool'),
+        builtin=dict(type='list'),
+    )
+
+    hand_inserted_arguments = dict(
+    )
+
+    argument_spec = dict()
+
+    argument_spec.update(netscaler_common_arguments)
+    argument_spec.update(module_specific_arguments)
+    argument_spec.update(hand_inserted_arguments)
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    module_result = dict(
+        changed=False,
+        failed=False,
+        loglines=loglines,
+    )
+
+    # Fail the module if imports failed
+    if not PYTHON_SDK_IMPORTED:
+        module.fail_json(msg='Could not load nitro python sdk')
+
+    # Fallthrough to rest of execution
+    client = get_nitro_client(module)
+
+    try:
+        client.login()
+    except nitro_exception as e:
+        msg = "nitro exception during login. errorcode=%s, message=%s" % (str(e.errorcode), e.message)
+        module.fail_json(msg=msg)
+    except Exception as e:
+        if str(type(e)) == "<class 'requests.exceptions.ConnectionError'>":
+            module.fail_json(msg='Connection error %s' % str(e))
+        elif str(type(e)) == "<class 'requests.exceptions.SSLError'>":
+            module.fail_json(msg='SSL Error %s' % str(e))
+        else:
+            module.fail_json(msg='Unexpected error during login %s' % str(e))
+
+    readwrite_attrs = [
+        'name',
+        'type',
+        'target',
+        'stringbuilderexpr',
+        'pattern',
+        'search',
+        'bypasssafetycheck',
+        'refinesearch',
+        'comment',
+        'newname'
+    ]
+
+    readonly_attrs = [
+        'hits',
+        'undefhits',
+        'referencecount',
+        'description',
+        'isdefault',
+        'builtin',
+        '__count'
+    ]
+
+    immutable_attrs = [
+        'name',
+        'type'
+    ]
+
+    transforms = {
+    }
+
+    # Instantiate config proxy
+    rewriteaction_proxy = ConfigProxy(
+        actual=rewriteaction(),
+        client=client,
+        attribute_values_dict=module.params,
+        readwrite_attrs=readwrite_attrs,
+        readonly_attrs=readonly_attrs,
+        immutable_attrs=immutable_attrs,
+        transforms=transforms,
+    )
+
+    try:
+        ensure_feature_is_enabled(client, 'rewrite')
+        # Apply appropriate state
+        if module.params['state'] == 'present':
+            if not rewriteaction_exists(client, module):
+                if not module.check_mode:
+                    rewriteaction_proxy.add()
+                    if module.params['save_config']:
+                        client.save_config()
+                module_result['changed'] = True
+            elif not rewriteaction_identical(client, module, rewriteaction_proxy):
+
+                # Check if we try to change value of immutable attributes
+                immutables_changed = get_immutables_intersection(rewriteaction_proxy, diff_list(client, module, rewriteaction_proxy).keys())
+                if immutables_changed != []:
+                    module.fail_json(msg='Cannot update immutable attributes %s' % (immutables_changed,), diff=diff_list(client, module, rewriteaction_proxy), **module_result)
+
+                if not module.check_mode:
+                    rewriteaction_proxy.update()
+                    if module.params['save_config']:
+                        client.save_config()
+                module_result['changed'] = True
+            else:
+                module_result['changed'] = False
+
+            # Sanity check for state
+            if not module.check_mode:
+                if not rewriteaction_exists(client, module):
+                    module.fail_json(msg='Rewrite action does not exist', **module_result)
+                if not rewriteaction_identical(client, module, rewriteaction_proxy):
+                    module.fail_json(msg='Rewrite action differs from configured', diff=diff_list(client, module, rewriteaction_proxy), **module_result)
+
+        elif module.params['state'] == 'absent':
+            if rewriteaction_exists(client, module):
+                if not module.check_mode:
+                    rewriteaction_proxy.delete()
+                    if module.params['save_config']:
+                        client.save_config()
+                module_result['changed'] = True
+            else:
+                module_result['changed'] = False
+
+            # Sanity check for state
+            if not module.check_mode:
+                if rewriteaction_exists(client, module):
+                    module.fail_json(msg='_ still exists', **module_result)
+
+    except nitro_exception as e:
+        msg = "nitro exception errorcode=%s, message=%s" % (str(e.errorcode), e.message)
+        module.fail_json(msg=msg, **module_result)
+
+    client.logout()
+    module.exit_json(**module_result)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible-modules/citrix_adc_rewrite_action.py
+++ b/ansible-modules/citrix_adc_rewrite_action.py
@@ -221,7 +221,7 @@ except ImportError as e:
     PYTHON_SDK_IMPORTED = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.netscaler.netscaler import (
+from ansible.module_utils.network.citrix_adc.citrix_adc import (
     ConfigProxy,
     get_nitro_client,
     netscaler_common_arguments,

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,3 +1,3 @@
 paramiko
-file:../netscaler-ansible-modules/deps/nitro-python-1.0_kamet.tar.gz
+file:../citrix-adc-ansible-modules/deps/nitro-python-1.0_kamet.tar.gz
 git+https://github.com/ansible/ansible.git

--- a/test/integration/netscaler_direct_calls/netscaler.yaml
+++ b/test/integration/netscaler_direct_calls/netscaler.yaml
@@ -10,10 +10,6 @@
     debug: false
 
   roles:
-    - { role: netscaler_appfw_policy, when: "limit_to in ['*', 'netscaler_appfw_policy']" }
-    - { role: netscaler_appfw_policylabel, when: "limit_to in ['*', 'netscaler_appfw_policylabel']" }
-    - { role: netscaler_appfw_profile, when: "limit_to in ['*', 'netscaler_appfw_profile']" }
-    - { role: netscaler_appfw_settings, when: "limit_to in ['*', 'netscaler_appfw_settings']" }
     - { role: netscaler_cs_action, when: "limit_to in ['*', 'netscaler_cs_action']" }
     - { role: netscaler_cs_policy, when: "limit_to in ['*', 'netscaler_cs_policy']" }
     - { role: netscaler_cs_vserver, when: "limit_to in ['*', 'netscaler_cs_vserver']" }
@@ -24,6 +20,7 @@
     - { role: netscaler_service, when: "limit_to in ['*', 'netscaler_service']" }
     - { role: netscaler_servicegroup, when: "limit_to in ['*', 'netscaler_servicegroup']" }
     - { role: netscaler_gslb_service, when: "limit_to in ['*', 'netscaler_gslb_service']" }
+    - { role: citrix_adc_rewrite_action, when: "limit_to in ['*', 'citrix_adc_rewrite_action']" }
     - { role: netscaler_gslb_site, when: "limit_to in ['*', 'netscaler_gslb_site']" }
     - { role: netscaler_gslb_vserver, when: "limit_to in ['*', 'netscaler_gslb_vserver']" }
     - { role: netscaler_nitro_request, when: "limit_to in ['*', 'netscaler_nitro_request']" }

--- a/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/defaults/main.yaml
+++ b/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/defaults/main.yaml
@@ -1,0 +1,6 @@
+---
+testcase: "*"
+test_cases: []
+
+nitro_user: nsroot
+nitro_pass: nsroot

--- a/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/sample_inventory
+++ b/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/sample_inventory
@@ -1,0 +1,5 @@
+
+
+[netscaler]
+
+netscaler01 nsip=172.18.0.2 nitro_user=nsroot nitro_pass=nsroot

--- a/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/tasks/main.yaml
+++ b/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/tasks/main.yaml
@@ -1,6 +1,2 @@
 ---
-
-- { include: testbed.yaml }
-
 - { include: nitro.yaml, tags: ['nitro'] }
-

--- a/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/tasks/nitro.yaml
+++ b/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/tasks/nitro.yaml
@@ -1,0 +1,14 @@
+- name: collect all nitro test cases
+  find:
+    paths: "{{ role_path }}/tests/nitro"
+    patterns: "{{ testcase }}.yaml"
+  register: test_cases
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test case
+  include: "{{ test_case_to_run }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/tests/nitro/rewriteaction.yaml
+++ b/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/tests/nitro/rewriteaction.yaml
@@ -1,0 +1,99 @@
+---
+
+- include: "{{ role_path }}/tests/nitro/rewriteaction/setup.yaml"
+  vars:
+    check_mode: yes
+
+- assert:
+    that: result is defined
+
+- include: "{{ role_path }}/tests/nitro/rewriteaction/setup.yaml"
+  vars:
+    check_mode: no
+
+- assert:
+    that: result is defined
+
+- include: "{{ role_path }}/tests/nitro/rewriteaction/setup.yaml"
+  vars:
+    check_mode: yes
+
+- assert:
+    that: not result|changed
+
+- include: "{{ role_path }}/tests/nitro/rewriteaction/setup.yaml"
+  vars:
+    check_mode: no
+
+- assert:
+    that: not result|changed
+
+- include: "{{ role_path }}/tests/nitro/rewriteaction/update.yaml"
+  vars:
+    check_mode: yes
+
+- assert:
+    that: result|changed
+
+- include: "{{ role_path }}/tests/nitro/rewriteaction/update.yaml"
+  vars:
+    check_mode: no
+
+- assert:
+    that: result|changed
+
+- include: "{{ role_path }}/tests/nitro/rewriteaction/update.yaml"
+  vars:
+    check_mode: yes
+
+- assert:
+    that: not result|changed
+
+- include: "{{ role_path }}/tests/nitro/rewriteaction/update.yaml"
+  vars:
+    check_mode: no
+
+- assert:
+    that: not result|changed
+
+- include: "{{ role_path }}/tests/nitro/rewriteaction/disable.yaml"
+  vars:
+    check_mode: yes
+
+- assert:
+    that: not result|changed
+
+- include: "{{ role_path }}/tests/nitro/rewriteaction/disable.yaml"
+  vars:
+    check_mode: no
+
+- assert:
+    that: not result|changed
+
+- include: "{{ role_path }}/tests/nitro/rewriteaction/remove.yaml"
+  vars:
+    check_mode: yes
+
+- assert:
+    that: result|changed
+
+- include: "{{ role_path }}/tests/nitro/rewriteaction/remove.yaml"
+  vars:
+    check_mode: no
+
+- assert:
+    that: result|changed
+
+- include: "{{ role_path }}/tests/nitro/rewriteaction/remove.yaml"
+  vars:
+    check_mode: yes
+
+- assert:
+    that: not result|changed
+
+- include: "{{ role_path }}/tests/nitro/rewriteaction/remove.yaml"
+  vars:
+    check_mode: no
+
+- assert:
+    that: not result|changed

--- a/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/tests/nitro/rewriteaction.yaml
+++ b/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/tests/nitro/rewriteaction.yaml
@@ -5,95 +5,81 @@
     check_mode: yes
 
 - assert:
-    that: result is defined
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/rewriteaction/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result is defined
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/rewriteaction/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/rewriteaction/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/rewriteaction/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/rewriteaction/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/rewriteaction/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/rewriteaction/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
-
-- include: "{{ role_path }}/tests/nitro/rewriteaction/disable.yaml"
-  vars:
-    check_mode: yes
-
-- assert:
-    that: not result|changed
-
-- include: "{{ role_path }}/tests/nitro/rewriteaction/disable.yaml"
-  vars:
-    check_mode: no
-
-- assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/rewriteaction/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/rewriteaction/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/rewriteaction/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/rewriteaction/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/tests/nitro/rewriteaction/remove.yaml
+++ b/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/tests/nitro/rewriteaction/remove.yaml
@@ -1,0 +1,14 @@
+---
+
+- name: Remove basic rewrite action
+  delegate_to: localhost
+  register: result
+  check_mode: "{{ check_mode }}"
+  citrix_adc_rewrite_action:
+    nitro_user: "{{nitro_user}}"
+    nitro_pass: "{{nitro_pass}}"
+    nsip: "{{nsip}}"
+
+    state: absent
+
+    name: test-rewriteaction-1

--- a/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/tests/nitro/rewriteaction/setup.yaml
+++ b/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/tests/nitro/rewriteaction/setup.yaml
@@ -1,0 +1,17 @@
+---
+
+- name: Setup basic rewrite action
+  delegate_to: localhost
+  register: result
+  check_mode: "{{ check_mode }}"
+  citrix_adc_rewrite_action:
+    nitro_user: "{{nitro_user}}"
+    nitro_pass: "{{nitro_pass}}"
+    nsip: "{{nsip}}"
+
+    state: present
+
+    name: test-rewriteaction-1
+    type: insert_http_header
+    target: "client-IP"
+    stringbuilderexpr: CLIENT.IP.SRC

--- a/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/tests/nitro/rewriteaction/update.yaml
+++ b/test/integration/netscaler_direct_calls/roles/citrix_adc_rewrite_action/tests/nitro/rewriteaction/update.yaml
@@ -1,0 +1,17 @@
+---
+
+- name: Update basic rewrite action target
+  delegate_to: localhost
+  register: result
+  check_mode: "{{ check_mode }}"
+  citrix_adc_rewrite_action:
+    nitro_user: "{{nitro_user}}"
+    nitro_pass: "{{nitro_pass}}"
+    nsip: "{{nsip}}"
+
+    state: present
+
+    name: test-rewriteaction-1
+    type: insert_http_header
+    target: "X-Forwarded-For"
+    stringbuilderexpr: CLIENT.IP.SRC

--- a/test/integration/netscaler_direct_calls/roles/netscaler_cs_action/tasks/main.yaml
+++ b/test/integration/netscaler_direct_calls/roles/netscaler_cs_action/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
-- { include: testbed.yaml, state: present }
+- { include: testbed.yaml }
 
 - { include: nitro.yaml, tags: ['nitro'] }
 
-- { include: testbed.yaml, state: absent }
+- { include: testbed.yaml }

--- a/test/integration/netscaler_direct_calls/roles/netscaler_cs_policy/tasks/main.yaml
+++ b/test/integration/netscaler_direct_calls/roles/netscaler_cs_policy/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
-- { include: testbed.yaml, state: present }
+- { include: testbed.yaml }
 
 - { include: nitro.yaml, tags: ['nitro'] }
 
-- { include: testbed.yaml, state: absent }
+- { include: testbed.yaml }

--- a/test/integration/netscaler_direct_calls/roles/netscaler_cs_vserver/tasks/main.yaml
+++ b/test/integration/netscaler_direct_calls/roles/netscaler_cs_vserver/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
-- { include: testbed.yaml, state: present }
+- { include: testbed.yaml }
 
 - { include: nitro.yaml, tags: ['nitro'] }
 
-- { include: testbed.yaml, state: absent }
+- { include: testbed.yaml }

--- a/test/integration/netscaler_direct_calls/roles/netscaler_gslb_service/tasks/main.yaml
+++ b/test/integration/netscaler_direct_calls/roles/netscaler_gslb_service/tasks/main.yaml
@@ -1,7 +1,5 @@
 ---
 
-- { include: testbed.yaml, state: present }
+- { include: testbed.yaml }
 
 - { include: nitro.yaml, tags: ['nitro'] }
-
-- { include: testbed.yaml, state: absent }

--- a/test/integration/netscaler_direct_calls/roles/netscaler_servicegroup/tasks/main.yaml
+++ b/test/integration/netscaler_direct_calls/roles/netscaler_servicegroup/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
-- { include: testbed.yaml, state: present }
+- { include: testbed.yaml }
 
 - { include: nitro.yaml, tags: ['nitro'] }
 
-- { include: testbed.yaml, state: absent }
+- { include: testbed.yaml }

--- a/utils/compile.py
+++ b/utils/compile.py
@@ -25,10 +25,10 @@ def produce_module_arguments_from_json_schema(json_doc, skip_attrs):
     for property in json_doc:
 
         # Skip attributes in skip_attrs
-        if property['option_name'] in skip_attrs:
+        if property['name'] in skip_attrs:
             continue
 
-        key = property['option_name']
+        key = property['name']
         entry = {}
         entry['key'] = key
         entry['transforms'] = []
@@ -62,7 +62,7 @@ def produce_module_arguments_from_json_schema(json_doc, skip_attrs):
 def produce_readwrite_attrs_list(json_doc):
     readwrite_attrs  = list()
     for property in json_doc:
-        readwrite_attrs .append(property['option_name'])
+        readwrite_attrs .append(property['name'])
     return readwrite_attrs
 
 
@@ -75,8 +75,8 @@ def produce_immutables_list(json_doc):
     immutables_list = []
     for property in json_doc:
         # Add only readonly attributes
-        if not property['is_updateable']:
-            immutables_list.append(property['option_name'])
+        if not property['readonly']:
+            immutables_list.append(property['name'])
     return immutables_list
 
 
@@ -110,11 +110,11 @@ def produce_module_argument_documentation(json_doc, config_class, skip_attrs):
     for property in json_doc:
 
         # Skip attributes in skip list
-        if property['option_name'] in skip_attrs:
+        if property['name'] in skip_attrs:
             continue
 
         entry = {}
-        entry['option_name'] = property['option_name']
+        entry['option_name'] = property['name']
 
         # Fallthrough
         # entry['description'] = [ split_description_line(line) for line in property['description_lines']]
@@ -140,7 +140,7 @@ def produce_module_argument_documentation(json_doc, config_class, skip_attrs):
                 entry['type'] = 'bool'
 
             # Append lines rejecting possible values lines
-            for line in property['description']:
+            for line in property['description_lines']:
                 if line.startswith('Possible values'):
                     continue
                 if choice_set in enabled_disabled_set:
@@ -156,7 +156,7 @@ def produce_module_argument_documentation(json_doc, config_class, skip_attrs):
                     entry['description'].append(split_description_line(line))
         else:
             # pass all lines to description
-            entry['description'] = [split_description_line(line) for line in property['description']]
+            entry['description'] = [split_description_line(line) for line in property['description_lines']]
 
         options_list.append(entry)
 
@@ -206,7 +206,7 @@ def main():
             sdk_property_list.append(member[0])
 
     # Show diffs
-    scrap_properties_set = set([v['option_name'] for v in json_doc])
+    scrap_properties_set = set([v['name'] for v in json_doc])
     sdk_properties_set = set(sdk_property_list)
 
     not_in_sdk = list(scrap_properties_set - sdk_properties_set)

--- a/utils/scrape.py
+++ b/utils/scrape.py
@@ -18,7 +18,7 @@ def scrape_page(page):
     htmltree = html.fromstring(r.content)
     with open('out.html', 'w') as fh:
         fh.write(html.tostring(htmltree))
-    tables = htmltree.xpath('''//div[@class='rst-content']//table''')
+    tables = htmltree.xpath('''//div//div//table''')
 
     if len(tables) == 0:
         raise Exception('Cannot find documentation table')
@@ -26,7 +26,7 @@ def scrape_page(page):
     if len(tables) > 1:
         raise Exception('Found too many documentation tables')
 
-    rows = htmltree.xpath('''//div[@class='rst-content']//table/tbody//tr''')
+    rows = htmltree.xpath('''//div//div//table/tbody//tr''')
     if len(rows) == 0:
         raise Exception('Could not find documentation table for %s' % page)
 


### PR DESCRIPTION
  - Added citrix_adc_rewrite_action ansible module
  - Added first citrix_adc_rewrite_action ansible module integration tests
  - Removed state parameter in include:testbed.yaml statements as it seems to have been deprecated by ansible.
  - Added python CI workflow with pylint error checking of Citrix ADC and Citrix ADM modules
  - Added missing success_status in citrix_adc_nitro_request count() 
  - Modified scrape.py and compile.py scriptsto match with new nitro api reference website layout
  - Updated requirements.test.txt to match current project name (renamed netscaler-ansible-modules to citrix-adc-ansible-modules)